### PR TITLE
[WIP] grafana: Allow HTML embedding, disable cookie cors security features

### DIFF
--- a/grafana/grafana.ini
+++ b/grafana/grafana.ini
@@ -3,3 +3,10 @@ data = /data/grafana
 
 [auth.anonymous]
 enabled = true
+
+[panels]
+disable_sanitize_html = true
+
+[security]
+allow_embedding = true
+cookie_samesite = disabled


### PR DESCRIPTION
To do:

- [ ] Make it optional, since it disables a security feature: [`cookie_samesite`](https://www.owasp.org/index.php/SameSite)

Change-type: minor
Signed-off-by: Tomás Migone <tomas@balena.io>